### PR TITLE
Resolved: Same user profile always returned

### DIFF
--- a/bangazon_api/views/profile_view.py
+++ b/bangazon_api/views/profile_view.py
@@ -28,7 +28,7 @@ class ProfileView(ViewSet):
     def my_profile(self, request):
         """Get the current user's profile"""
         try:
-            serializer = UserSerializer(User.objects.first())
+            serializer = UserSerializer(User.objects.get(pk=request.auth.user.id))
             return Response(serializer.data)
         except User.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
# Description

Current user profile retrieved on "my-profile" custom action. See profile_view.py line 31. Was previously retrieving the first object instance each time.

Fixes #2 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A- tested in Swagger with "my_profile" method
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
