### PR TITLE
Resolved: Division by zero error on products

### DIFF
--- a/bangazon_api/models/product.py
+++ b/bangazon_api/models/product.py
@@ -32,8 +32,11 @@ class Product(models.Model):
         for rating in self.ratings.all():
             total_rating += rating.score
 
-        avg = total_rating / self.ratings.count()
-        return avg
+        try:
+            avg = total_rating / self.ratings.count()
+            return avg
+        except ZeroDivisionError:
+            return 0
 
     @property
     def number_purchased(self):


### PR DESCRIPTION
# Description

On zeroDivisionError for average_rating, return 0 instead of the calculated average

Fixes #9 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [X] Test A- Added a new store and product to test in Swagger, since all existing products have ratings. Without try/except, average_rating is null. With it, average_rating is 0.
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
